### PR TITLE
Fix preview removal when adding shapes

### DIFF
--- a/code.ts
+++ b/code.ts
@@ -14,38 +14,42 @@ function hexToRgb(hex: string): RGB {
 
 interface UpdateMessage {
   type: 'update';
+  add?: boolean;
   shape: string;
   edges?: number;
+  width: number;
+  height: number;
+  rotation: number;
   color?: string;
   gradientFrom?: string;
   gradientTo?: string;
 }
 
-let currentNode: SceneNode | null = null;
+let previewNode: SceneNode | null = null;
 
-function createShape(shape: string, edges: number): SceneNode {
+function createShape(shape: string, edges: number, width: number, height: number): SceneNode {
   let node: SceneNode;
   switch (shape) {
     case 'circle':
       node = figma.createEllipse();
-      (node as EllipseNode).resize(100, 100);
+      (node as EllipseNode).resize(width, height);
       break;
     case 'ellipse':
       node = figma.createEllipse();
-      (node as EllipseNode).resize(150, 100);
+      (node as EllipseNode).resize(width, height);
       break;
     case 'square':
       node = figma.createRectangle();
-      (node as RectangleNode).resize(100, 100);
+      (node as RectangleNode).resize(width, height);
       break;
     case 'rectangle':
       node = figma.createRectangle();
-      (node as RectangleNode).resize(150, 100);
+      (node as RectangleNode).resize(width, height);
       break;
     case 'polygon':
       node = figma.createPolygon();
       (node as PolygonNode).pointCount = edges;
-      (node as PolygonNode).resize(150, 150);
+      (node as PolygonNode).resize(width, height);
       break;
     default:
       node = figma.createRectangle();
@@ -88,15 +92,39 @@ function applyFill(node: SceneNode, colorHex?: string, fromHex?: string, toHex?:
 
 figma.ui.onmessage = (msg: UpdateMessage | { type: 'cancel' }) => {
   if (msg.type === 'update') {
-    const { shape, edges = 3, color, gradientFrom, gradientTo } = msg;
-    if (currentNode) currentNode.remove();
-    currentNode = createShape(shape, edges);
-    applyFill(currentNode, color, gradientFrom, gradientTo);
-    figma.currentPage.appendChild(currentNode);
-    figma.currentPage.selection = [currentNode];
-    figma.viewport.scrollAndZoomIntoView([currentNode]);
+    const {
+      add = false,
+      shape,
+      edges = 3,
+      width,
+      height,
+      rotation,
+      color,
+      gradientFrom,
+      gradientTo,
+    } = msg;
+
+    if (add) {
+      if (!previewNode) {
+        previewNode = createShape(shape, edges, width, height);
+        applyFill(previewNode, color, gradientFrom, gradientTo);
+        (previewNode as LayoutMixin).rotation = rotation;
+        figma.currentPage.appendChild(previewNode);
+        figma.currentPage.selection = [previewNode];
+        figma.viewport.scrollAndZoomIntoView([previewNode]);
+      }
+      previewNode = null;
+    } else {
+      if (previewNode) previewNode.remove();
+      previewNode = createShape(shape, edges, width, height);
+      (previewNode as LayoutMixin).rotation = rotation;
+      applyFill(previewNode, color, gradientFrom, gradientTo);
+      figma.currentPage.appendChild(previewNode);
+      figma.currentPage.selection = [previewNode];
+      figma.viewport.scrollAndZoomIntoView([previewNode]);
+    }
   } else if (msg.type === 'cancel') {
-    if (currentNode) currentNode.remove();
+    if (previewNode) previewNode.remove();
     figma.closePlugin();
   }
 };

--- a/ui.html
+++ b/ui.html
@@ -25,6 +25,16 @@
   From: <input id="gradientFrom" type="color" value="#ff0000" />
   To: <input id="gradientTo" type="color" value="#0000ff" />
 </p>
+<p>
+  Width: <input id="width" type="range" min="10" max="300" value="100" />
+</p>
+<p>
+  Height: <input id="height" type="range" min="10" max="300" value="100" />
+</p>
+<p>
+  Rotation: <input id="rotation" type="range" min="0" max="360" value="0" />
+</p>
+<button id="add">Add Shape</button>
 <button id="cancel">Close</button>
 <script>
 const shapeEl = document.getElementById('shape');
@@ -33,6 +43,9 @@ const useGradientEl = document.getElementById('useGradient');
 const colorEl = document.getElementById('color');
 const gradientFromEl = document.getElementById('gradientFrom');
 const gradientToEl = document.getElementById('gradientTo');
+const widthEl = document.getElementById('width');
+const heightEl = document.getElementById('height');
+const rotationEl = document.getElementById('rotation');
 
 function updateVisibility() {
   document.getElementById('polygon-options').style.display = shapeEl.value === 'polygon' ? 'block' : 'none';
@@ -40,11 +53,15 @@ function updateVisibility() {
   document.getElementById('color-section').style.display = useGradientEl.checked ? 'none' : 'block';
 }
 
-function sendUpdate() {
-  const message = {
+function sendUpdate(add = false) {
+  const message: any = {
     type: 'update',
+    add,
     shape: shapeEl.value,
     edges: parseInt(edgesEl.value, 10) || 3,
+    width: parseInt(widthEl.value, 10) || 100,
+    height: parseInt(heightEl.value, 10) || 100,
+    rotation: parseInt(rotationEl.value, 10) || 0,
   };
   if (useGradientEl.checked) {
     message.gradientFrom = gradientFromEl.value;
@@ -61,6 +78,10 @@ useGradientEl.onchange = () => { updateVisibility(); sendUpdate(); };
 colorEl.oninput = sendUpdate;
 gradientFromEl.oninput = sendUpdate;
 gradientToEl.oninput = sendUpdate;
+widthEl.oninput = sendUpdate;
+heightEl.oninput = sendUpdate;
+rotationEl.oninput = sendUpdate;
+document.getElementById('add').onclick = () => sendUpdate(true);
 window.onload = () => { updateVisibility(); sendUpdate(); };
 document.getElementById('cancel').onclick = () => {
   parent.postMessage({ pluginMessage: { type: 'cancel' } }, '*');


### PR DESCRIPTION
## Summary
- maintain a preview node separate from added shapes
- only remove preview node when updating or closing

## Testing
- `npm run lint`
- `npm run build`
